### PR TITLE
4 infinte loop in tsqubo iterate cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ int main() {
   free(instance);
 
   // initialise solution vectors and queues
+  tsqubo_reset_solutions(ts);
   tsqubo_reset_tabu(ts);
 
   // run TS until no improved solutions are found for 5 consecutive iterations

--- a/tsqubo.h
+++ b/tsqubo.h
@@ -394,14 +394,14 @@ void tsqubo_reset_tabu(struct tsqubo *ts) {
 void tsqubo_flip_current(struct tsqubo *ts, size_t i) {
   ts->cur.fx += ts->cur.dx[i];
   ts->cur.x[i] = 1 - ts->cur.x[i];
+  ts->cur.dx[i] *= -1;
   for (size_t k = ts->inst.R[i]; k < ts->inst.R[i + 1]; k++) {
     size_t j = ts->inst.C[k];
 #ifdef TSQUBO_SPARSE
     double d = ts->cur.dx[j];
 #endif
-    ts->cur.dx[j] =
-        j == i ? -ts->cur.dx[j]
-               : ts->cur.dx[j] - (1 - 2 * ts->cur.x[i]) * (1 - 2 * ts->cur.x[j]) * ts->inst.Q[k];
+    if (i != j)
+    ts->cur.dx[j] -= (1 - 2 * ts->cur.x[i]) * (1 - 2 * ts->cur.x[j]) * ts->inst.Q[k];
 #ifdef TSQUBO_SPARSE
     if (ts->cur.dx[j] < d) {
       if (ipq_contains(&ts->d, j)) ipq_sift_down(&ts->d, ts->cur.dx, compare_double, ts->d.I[j]);


### PR DESCRIPTION
Fixes #4 , the output of the script

```c
#define TSQUBO_SPARSE
#include <stdio.h>
#include "tsqubo.h"

int main() {
  // create a QUBO instance and add some components to the matrix
  struct tsqubo_instance *instance = tsqubo_instance_new(/* initial capacity for components */ 4);
  tsqubo_instance_add_component(instance, 0, 0, -2);
  tsqubo_instance_add_component(instance, 2, 2, 5);
  tsqubo_instance_add_component(instance, 0, 1, -1);

  // create a TS instance that will solve the QUBO instance
  struct tsqubo *ts = tsqubo_new(instance);
  tsqubo_instance_free(instance);
  free(instance);

  // initialise solution vectors and queues
  tsqubo_reset_solutions(ts);
  tsqubo_reset_tabu(ts);

  // run TS until no improved solutions are found for 5 consecutive iterations
  size_t tabu_tenure_constant = 10, improvement_cutoff = 5;
  tsqubo_iterate_cutoff(ts, tabu_tenure_constant, improvement_cutoff);

  // print the best solution value
  printf("%lf\n", ts->inc.fx);

  tsqubo_free(ts);
  free(ts);
  return 0;
}
```
is now:
```
-4.000000
```